### PR TITLE
Overloaded move and moveTo methods to add horizontal scroll

### DIFF
--- a/src/HID-APIs/AbsoluteMouseAPI.h
+++ b/src/HID-APIs/AbsoluteMouseAPI.h
@@ -68,9 +68,10 @@ public:
 	inline void end(void);
 
 	inline void click(uint8_t b = MOUSE_LEFT);
+	inline void moveTo(int x, int y, signed char wheel = 0, signed char hWheel = 0);
 	inline void moveTo(int x, int y, signed char wheel = 0);
+	inline void move(int x, int y, signed char wheel = 0, signed char hWheel = 0);
 	inline void move(int x, int y, signed char wheel = 0);
-	inline void scroll(signed char wheel = 0, signed char hWheel = 0);
 	inline void press(uint8_t b = MOUSE_LEFT);
 	inline void release(uint8_t b = MOUSE_LEFT);
 	inline void releaseAll(void);

--- a/src/HID-APIs/AbsoluteMouseAPI.h
+++ b/src/HID-APIs/AbsoluteMouseAPI.h
@@ -69,9 +69,7 @@ public:
 
 	inline void click(uint8_t b = MOUSE_LEFT);
 	inline void moveTo(int x, int y, signed char wheel = 0, signed char hWheel = 0);
-	inline void moveTo(int x, int y, signed char wheel = 0);
 	inline void move(int x, int y, signed char wheel = 0, signed char hWheel = 0);
-	inline void move(int x, int y, signed char wheel = 0);
 	inline void press(uint8_t b = MOUSE_LEFT);
 	inline void release(uint8_t b = MOUSE_LEFT);
 	inline void releaseAll(void);

--- a/src/HID-APIs/AbsoluteMouseAPI.hpp
+++ b/src/HID-APIs/AbsoluteMouseAPI.hpp
@@ -89,16 +89,8 @@ void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel, signed char hWhee
 	SendReport(&report, sizeof(report));
 }
 
-void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
-	moveTo(x, y, wheel, 0);
-}
-
 void AbsoluteMouseAPI::move(int x, int y, signed char wheel, signed char hWheel){
 	moveTo(qadd16(xAxis, x), qadd16(yAxis, y), wheel, hWheel);
-}
-
-void AbsoluteMouseAPI::move(int x, int y, signed char wheel){
-	move(x, y, wheel, 0);
 }
 
 void AbsoluteMouseAPI::press(uint8_t b){

--- a/src/HID-APIs/AbsoluteMouseAPI.hpp
+++ b/src/HID-APIs/AbsoluteMouseAPI.hpp
@@ -73,7 +73,7 @@ void AbsoluteMouseAPI::click(uint8_t b){
 	moveTo(xAxis, yAxis, 0);
 }
 
-void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
+void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel, signed char hWheel){
 	xAxis = x;
 	yAxis = y;
 	HID_MouseAbsoluteReport_Data_t report;
@@ -85,18 +85,20 @@ void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
 	report.xAxis = ((int32_t)x + 32768) / 2;
 	report.yAxis = ((int32_t)y + 32768) / 2;
 	report.wheel = wheel;
+	report.hWheel = hWheel;
 	SendReport(&report, sizeof(report));
+}
+
+void AbsoluteMouseAPI::moveTo(int x, int y, signed char wheel){
+	moveTo(x, y, wheel, 0);
+}
+
+void AbsoluteMouseAPI::move(int x, int y, signed char wheel, signed char hWheel){
+	moveTo(qadd16(xAxis, x), qadd16(yAxis, y), wheel, hWheel);
 }
 
 void AbsoluteMouseAPI::move(int x, int y, signed char wheel){
-	moveTo(qadd16(xAxis, x), qadd16(yAxis, y), wheel);
-}
-
-void AbsoluteMouseAPI::scroll(signed char wheel, signed char hWheel){
-	HID_MouseAbsoluteReport_Data_t report;
-	report.wheel = wheel;
-	report.hWheel = hWheel;
-	SendReport(&report, sizeof(report));
+	move(x, y, wheel, 0);
 }
 
 void AbsoluteMouseAPI::press(uint8_t b){


### PR DESCRIPTION
The scroll method has been removed in favour of a better approach via method overloading. Mouse move functionality was not fully implemented in the scroll method. Doing so would require adding parameters already present on the moveTo() method.